### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
     "name" : "Inline::Ruby",
+    "license" : "Artistic-2.0",
     "version" : "0.4.0",
     "author" : "github:awwaiid",
     "description" : "Use Ruby code and libraries in a Perl 6 program",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license