### PR TITLE
Fixed Panda::Common dependency refs #4

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -1,10 +1,8 @@
 use v6;
-use Panda::Common;
-use Panda::Builder;
 use Shell::Command;
 use LibraryMake;
 
-class Build is Panda::Builder {
+class Build {
 
   #| Call out to Ruby to figure out what compile flags we should use
   sub ruby-cc-config {
@@ -20,7 +18,7 @@ class Build is Panda::Builder {
       '
     }, :out);
     my $rb-config = $rb-config-cmd.out.slurp;
-
+    note $rb-config;
     $rb-config;
   }
 


### PR DESCRIPTION
But still there are problems to compile it.
I do perl6 configure.pl6, then zef build ., and then zef test, but it fails saying it can't find some static code. Same with make test:
```
prove -e 'perl6 -Ilib' t
t/eval.t ................ Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

===SORRY!===
Serialization Error: missing static code ref for closure '' (perl#sources/24DD121B5B4774C04A7084827BFAD92199756E03 (NativeCall):526)
t/eval.t ................ Dubious, test returned 1 (wstat 256, 0x100)
No subtests run 
t/eval_return_values.t .. Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

===SORRY!===
Serialization Error: missing static code ref for closure '' (perl#sources/24DD121B5B4774C04A7084827BFAD92199756E03 (NativeCall):526)
t/eval_return_values.t .. Dubious, test returned 1 (wstat 256, 0x100)
No subtests run 
t/rb_to_p6.t ............ Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

===SORRY!===
Serialization Error: missing static code ref for closure '' (perl#sources/24DD121B5B4774C04A7084827BFAD92199756E03 (NativeCall):526)
t/rb_to_p6.t ............ Dubious, test returned 1 (wstat 256, 0x100)
No subtests run 
t/sweet.t ............... Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

Cannot locate native library '/home/jmerelo/Code/forks/perl6/p6-Inline-Ruby/resources/libraries/librbhelper.so': libruby.so.2.3: cannot open shared object file: No such file or directory

===SORRY!===
Serialization Error: missing static code ref for closure '' (perl#sources/24DD121B5B4774C04A7084827BFAD92199756E03 (NativeCall):526)
t/sweet.t ............... Dubious, test returned 1 (wstat 256, 0x100)
No subtests run 

Test Summary Report
-------------------
t/eval.t              (Wstat: 256 Tests: 0 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
t/eval_return_values.t (Wstat: 256 Tests: 0 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
t/rb_to_p6.t          (Wstat: 256 Tests: 0 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
t/sweet.t             (Wstat: 256 Tests: 0 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
Files=4, Tests=0,  4 wallclock secs ( 0.02 usr  0.00 sys +  5.84 cusr  0.39 csys =  6.25 CPU)
Result: FAIL
make: *** [test] Error 1
```
I'm using perl6 2018.06 with rvm, with ruby 2.3 selected by rvm. 
